### PR TITLE
added urlPrefix for development environment

### DIFF
--- a/client/src/components/pages/Actor.js
+++ b/client/src/components/pages/Actor.js
@@ -10,6 +10,7 @@ import {
   Center,
 } from "@chakra-ui/react";
 import axios from "axios";
+import { urlPrefix } from "../../utils/constants";
 import { useParams } from "react-router";
 import moment from "moment";
 
@@ -26,7 +27,7 @@ function Actor() {
     console.log(actor);
     axios({
       method: "GET",
-      url: "/actors/" + actor,
+      url: urlPrefix + "/actors/" + actor,
     })
       .then((response) => {
         const res = response.data;
@@ -49,7 +50,7 @@ function Actor() {
   function getPersonImageLink(target) {
     axios({
       method: "POST",
-      url: "/person-image-link/",
+      url: urlPrefix + "/person-image-link/",
       data: { person_name: target },
     })
       .then((response) => {
@@ -69,7 +70,7 @@ function Actor() {
   function getAppearances(target) {
     axios({
       method: "GET",
-      url: "/actor-appearances/" + target,
+      url: urlPrefix + "/actor-appearances/" + target,
     })
       .then((response) => {
         const res = response.data;
@@ -98,7 +99,7 @@ function Actor() {
   function getPersonImageLink2(target) {
     axios({
       method: "POST",
-      url: "/person-image-link2/",
+      url: urlPrefix + "/person-image-link2/",
       data: { person_id: target },
     })
       .then((response) => {
@@ -119,7 +120,7 @@ function Actor() {
   function getActorDetails(target) {
     axios({
       method: "POST",
-      url: "/actor-details/",
+      url: urlPrefix + "/actor-details/",
       data: { person_id: target },
     })
       .then((response) => {

--- a/client/src/components/pages/Genre.js
+++ b/client/src/components/pages/Genre.js
@@ -9,6 +9,7 @@ import {
   Container,
 } from "@chakra-ui/react";
 import axios from "axios";
+import { urlPrefix } from "../../utils/constants";
 import { useParams } from "react-router";
 import moment from "moment";
 
@@ -27,7 +28,7 @@ function Genre() {
   function getGenre() {
     axios({
       method: "GET",
-      url: "/genres/" + genre,
+      url: urlPrefix + "/genres/" + genre,
     })
       .then((response) => {
         const res = response.data;
@@ -46,7 +47,7 @@ function Genre() {
   function getPersonImageLink() {
     axios({
       method: "POST",
-      url: "/person-image-link/",
+      url: urlPrefix + "/person-image-link/",
       data: { person_name: personName },
     })
       .then((response) => {
@@ -66,7 +67,7 @@ function Genre() {
   function getMoviePosterLink(target) {
     axios({
       method: "POST",
-      url: "/movie-poster-link/",
+      url: urlPrefix + "/movie-poster-link/",
       data: { movie_name: target },
     })
       .then((response) => {
@@ -86,7 +87,7 @@ function Genre() {
   function getMovies(target) {
     axios({
       method: "GET",
-      url: "/genre-movies/" + target,
+      url: urlPrefix + "/genre-movies/" + target,
     })
       .then((response) => {
         const res = response.data;
@@ -121,7 +122,7 @@ function Genre() {
   function getMoviePosterLink2(target) {
     axios({
       method: "POST",
-      url: "/movie-poster-link2/",
+      url: urlPrefix + "/movie-poster-link2/",
       data: { movie_id: target },
     })
       .then((response) => {

--- a/client/src/components/pages/Home.js
+++ b/client/src/components/pages/Home.js
@@ -2,6 +2,7 @@ import React, { useEffect } from "react";
 import { useState } from "react";
 import { Text, Heading, Link, Box, Flex } from "@chakra-ui/react";
 import axios from "axios";
+import { urlPrefix } from "../../utils/constants";
 
 function Home() {
   const [genrelist, setGenreList] = useState(null);
@@ -9,7 +10,7 @@ function Home() {
   function getData() {
     axios({
       method: "GET",
-      url: "/genre-list-link/",
+      url: urlPrefix + "/genre-list-link/",
     })
       .then((response) => {
         const res = response.data;

--- a/client/src/components/pages/Movie.js
+++ b/client/src/components/pages/Movie.js
@@ -11,6 +11,7 @@ import {
   Divider,
 } from "@chakra-ui/react";
 import axios from "axios";
+import { urlPrefix } from "../../utils/constants";
 import { useParams } from "react-router";
 import moment from "moment";
 
@@ -30,7 +31,7 @@ function Movie() {
     console.log(movie);
     axios({
       method: "GET",
-      url: "/movies/" + movie,
+      url: urlPrefix + "/movies/" + movie,
     })
       .then((response) => {
         const res = response.data;
@@ -55,7 +56,7 @@ function Movie() {
   function getMoviePosterLink(target) {
     axios({
       method: "POST",
-      url: "/movie-poster-link/",
+      url: urlPrefix + "/movie-poster-link/",
       data: { movie_name: target },
     })
       .then((response) => {
@@ -76,7 +77,7 @@ function Movie() {
     console.log("STARTING THE REQUEST");
     axios({
       method: "GET",
-      url: "/movie-credits/" + target,
+      url: urlPrefix + "/movie-credits/" + target,
     })
       .then((response) => {
         const res = response.data;
@@ -105,7 +106,7 @@ function Movie() {
   function getMoviePosterLink2(target) {
     axios({
       method: "POST",
-      url: "/movie-poster-link2/",
+      url: urlPrefix + "/movie-poster-link2/",
       data: { movie_id: target },
     })
       .then((response) => {
@@ -125,7 +126,7 @@ function Movie() {
   function getMovieDetails(target) {
     axios({
       method: "POST",
-      url: "/movie-details/",
+      url: urlPrefix + "/movie-details/",
       data: { movie_id: target },
     })
       .then((response) => {
@@ -218,7 +219,7 @@ function Movie() {
   function getKeywords(target) {
     axios({
       method: "POST",
-      url: "/movie-keywords/",
+      url: urlPrefix + "/movie-keywords/",
       data: { movie_id: target },
     })
       .then((response) => {
@@ -238,7 +239,7 @@ function Movie() {
   function getRecs(gTarget, kTarget) {
     axios({
       method: "POST",
-      url: "/movie-recs/",
+      url: urlPrefix + "/movie-recs/",
       data: { genre: gTarget, keyword: kTarget },
     })
       .then((response) => {

--- a/client/src/utils/constants.js
+++ b/client/src/utils/constants.js
@@ -1,0 +1,6 @@
+const developmentURLPrefix = "http://127.0.0.1:5000";
+const productionURLPrefix = "";
+export const urlPrefix =
+  process.env.NODE_ENV === "development"
+    ? developmentURLPrefix
+    : productionURLPrefix;


### PR DESCRIPTION
This works on my machine as a React development environment.
- Start the python server in root
- cd to client and run npm start -- changes to the React code are updated and the routes work on my machine

I created a file client/src/utils/constants.js that exports a urlPrefix which for the python server on my local machine is "http://127.0.0.1:5000".  This could be different for others depending on how their python server is set up.  Anyway, the urlPrefix should change depending on whether the environment is development or production and I added the urlPrefix to (hopefully) all of the axios API calls.

We should:
- check whether this approach works when built and deployed.
- consider adding constants.js to .gitignore so that if folks have different python server settings, those settings don't accidentally get included in unrelated PR's

Source for this approach is: https://a-carreras-c.medium.com/development-and-production-variables-for-react-apps-c04af8b430a5